### PR TITLE
[FIX] it is possible that temporary NSManagedObjects get created with a ...

### DIFF
--- a/Classes/GDConcurrencyCheckingManagedObject.m
+++ b/Classes/GDConcurrencyCheckingManagedObject.m
@@ -147,6 +147,9 @@ static void *EnsureContextHasConcurrencyIdentifier(NSManagedObjectContext *conte
 static BOOL ValidateConcurrency(NSManagedObject *object, SEL _cmd)
 {
     void *desiredConcurrencyIdentifier = (void *)objc_getAssociatedObject(object, ConcurrencyIdentifierKey);
+    if(nil == desiredConcurrencyIdentifier) {
+        return YES;
+    }
     BOOL concurrencyValid = (CurrentConcurrencyIdentifierForManagedObject(object) == desiredConcurrencyIdentifier);
     if (!concurrencyValid) {
         if (GDConcurrencyFailureFunction) GDConcurrencyFailureFunction(_cmd);


### PR DESCRIPTION
[FIX] it is possible that temporary NSManagedObjects get created with a nil context, in which case the desiredConcurrencyIdentifier may be nil, even though correct concurrency is being respected.  This seems to fix the numerous logged errors.  Example case:

// create a temporary NSManagedObject
NSEntityDescription *entity = [NSEntityDescription entityForName:@"EntityName"
                                              inManagedObjectContext:moc];
__block NSManagedObject *obj = nil;
 [moc performBlockAndWait:^{
        obj = [[NSManagedObject alloc] initWithEntity:entity insertIntoManagedObjectContext:nil];
        obj.key = @"value";
    }];

// use obj here, validate etc. in the correct moc performBlock

// insert into some moc at some later point / or not
 [moc performBlockAndWait:^{
    [moc insertObject:obj];
    }];
