### PR TITLE
Add capacity to enable/disable logs with preprocessor macro and add capacity to raise exception

### DIFF
--- a/Classes/GDConcurrencyCheckingManagedObject.m
+++ b/Classes/GDConcurrencyCheckingManagedObject.m
@@ -48,16 +48,15 @@ static void *GDInAutoreleaseState_NotInAutorelease = NULL;
 static void *GDInAutoreleaseState_InAutorelease = &GDInAutoreleaseState_InAutorelease;
 
 NSUInteger GDOperationQueueConcurrencyType = 
+#ifdef GDCOREDATACONCURRENCYDEBUGGING_DISABLED
+NSConfinementConcurrencyType;
+#else
+42;
+#endif
 
 #ifdef GD_CORE_DATA_CONCURRENCE_DEBUGGING_ENABLE_EXCEPTION
 static NSString *const GDInvalidConcurrentAccesOnReleaseException = @"GDInvalidConcurrentAccesOnReleaseException";
 static NSString *const GDInvalidConcurrentAccesException = @"GDInvalidConcurrentAccesException";
-#endif
-
-#ifdef GDCOREDATACONCURRENCYDEBUGGING_DISABLED
-    NSConfinementConcurrencyType;
-#else
-    42;
 #endif
 
 #define WhileLocked(block) do { \


### PR DESCRIPTION
I added a preprocessor macro to disable logging (by default, logs are printed).

I added a preprocessor macro to enable raise of exception on invalid concurrency operations in addition of the existing log.

It is possible to use the macro directly in your pod files :
post_install do |installer|
    target = installer.project.targets.find{|t| t.to_s == "Pods-GDCoreDataConcurrencyDebugging"}
    target.build_configurations.each do |config|
        s = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS']
        s = [ '$(inherited)' ] if s == nil;
        s.push('GD_CORE_DATA_CONCURRENCE_DEBUGGING_ENABLE_EXCEPTION=1') if config.to_s == "Debug";
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = s
    end
end

Or

post_install do |installer|
    target = installer.project.targets.find{|t| t.to_s == "Pods-GDCoreDataConcurrencyDebugging"}
    target.build_configurations.each do |config|
        s = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS']
        s = [ '$(inherited)' ] if s == nil;
        s.push('GD_CORE_DATA_CONCURRENCE_DEBUGGING_DISABLE_LOG=1') if config.to_s == "Debug";
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = s
    end
end
